### PR TITLE
solve BOJ1158

### DIFF
--- a/BOJ/연결리스트/boj1158.cpp
+++ b/BOJ/연결리스트/boj1158.cpp
@@ -1,0 +1,33 @@
+// BOJ 1158번 요세푸스 문제
+#include <bits/stdc++.h>
+using namespace std;
+
+int main(void)
+{
+    ios::sync_with_stdio(0);
+    cin.tie(0);
+    int n, k;
+    cin >> n >> k;
+    list<int> L;
+    for (int i = 1; i <= n; i++)
+        L.push_back(i);
+    list<int>::iterator t = L.begin();
+    cout << '<';
+    while (L.size() > 1)
+    {
+        // vector을 이용하면 for문을 쓰지 않고 인덱스로 나머지 연산
+        // 지울 인덱스 = (현재 인덱스 + k-1) % 현재 벡터 크기
+        for (int i = 0; i < k - 1; i++) // k만큼 옆으로 한 칸씩 감
+        {
+            if (t == L.end())  // 마지막 원소 다음을 가리키면
+                t = L.begin(); // 맨 앞으로 감
+            t++;
+        }
+        if (t == L.end()) // for문이 끝나고 한번 더 확인해야 함
+            t = L.begin();
+        cout << *t << ", ";
+        t = L.erase(t);
+    }
+    cout << L.front() << '>' << '\n';
+    return 0;
+}


### PR DESCRIPTION
백준 1158번 요세푸스 문제 풀었습니다!
연결리스트 이용해서 시간복잡도 O(NK)로 풀었는데 더 줄일 수 있는 방법이 있을 거 같습니다.🤔
바킹독님은 벡터로 나누기 연산 사용해서 O(N)으로 푸셨더라구요!